### PR TITLE
Release: diode-sdk-python

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,6 +168,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
+          skip-existing: true
 
   semantic-release:
     name: Semantic release


### PR DESCRIPTION
- fix: GHA - release: add missing package.json and releaserc.json