### PR TITLE
fix: GHA lint and tests workflow permissions

### DIFF
--- a/.github/workflows/lint-tests.yml
+++ b/.github/workflows/lint-tests.yml
@@ -10,6 +10,11 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
+permissions:
+  contents: write
+  checks: write
+  pull-requests: write
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When dependabot creates a pull request, triggered github actions have read permissions only, and i.e. `MishaKav/pytest-coverage-comment` fails to submit a comment, see [failing PR from dependabot](https://github.com/netboxlabs/diode-sdk-python/actions/runs/9815772186/job/27110732248?pr=7).