### PR TITLE
release: bump certifi

### DIFF
--- a/.github/workflows/lint-tests.yml
+++ b/.github/workflows/lint-tests.yml
@@ -10,6 +10,11 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
+permissions:
+  contents: write
+  checks: write
+  pull-requests: write
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,7 +168,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
-          skip-existing: true
 
   semantic-release:
     name: Semantic release

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please send any suspected vulnerability report to security@netboxlabs.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [  # Optional
 ]
 
 dependencies = [
-    "certifi==2024.2.2",
+    "certifi==2024.7.4",
     "grpcio==1.62.1",
     "grpcio-status==1.62.1",
     "sentry-sdk>=2.2.1",


### PR DESCRIPTION
- bump [certifi](https://github.com/certifi/python-certifi) from 2024.2.2 to 2024.7.4