### PR TITLE
feat: set primary user agent

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*                     @leoparente @mfiedorowicz @natm
+*                     @leoparente @mfiedorowicz

--- a/netboxlabs/diode/sdk/client.py
+++ b/netboxlabs/diode/sdk/client.py
@@ -102,6 +102,10 @@ class DiodeClient:
             ("python-version", self._python_version),
         )
 
+        channel_opts = (
+            ("grpc.primary_user_agent", f"{self._name}/{self._version} {self._app_name}/{self._app_version}"),
+        )
+
         if self._tls_verify:
             _LOGGER.debug("Setting up gRPC secure channel")
             self._channel = grpc.secure_channel(
@@ -109,11 +113,13 @@ class DiodeClient:
                 grpc.ssl_channel_credentials(
                     root_certificates=_load_certs(),
                 ),
+                options=channel_opts,
             )
         else:
             _LOGGER.debug("Setting up gRPC insecure channel")
             self._channel = grpc.insecure_channel(
                 target=self._target,
+                options=channel_opts,
             )
 
         channel = self._channel

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -231,6 +231,46 @@ def test_client_sets_up_insecure_channel_when_grpc_scheme_is_found_in_target():
         mock_insecure_channel.assert_called_once()
 
 
+def test_insecure_channel_options_with_primary_user_agent():
+    """Check that DiodeClient.__init__() sets the gRPC primary_user_agent option for insecure channel."""
+    with mock.patch("grpc.insecure_channel") as mock_insecure_channel:
+        client = DiodeClient(
+            target="grpc://localhost:8081",
+            app_name="my-producer",
+            app_version="0.0.1",
+            api_key="abcde",
+        )
+
+        mock_insecure_channel.assert_called_once()
+        _, kwargs = mock_insecure_channel.call_args
+        assert kwargs["options"] == (
+            (
+                "grpc.primary_user_agent",
+                f"{client.name}/{client.version} {client.app_name}/{client.app_version}",
+            ),
+        )
+
+
+def test_secure_channel_options_with_primary_user_agent():
+    """Check that DiodeClient.__init__() sets the gRPC primary_user_agent option for secure channel."""
+    with mock.patch("grpc.secure_channel") as mock_secure_channel:
+        client = DiodeClient(
+            target="grpcs://localhost:8081",
+            app_name="my-producer",
+            app_version="0.0.1",
+            api_key="abcde",
+        )
+
+        mock_secure_channel.assert_called_once()
+        _, kwargs = mock_secure_channel.call_args
+        assert kwargs["options"] == (
+            (
+                "grpc.primary_user_agent",
+                f"{client.name}/{client.version} {client.app_name}/{client.app_version}",
+            ),
+        )
+
+
 def test_client_interceptor_setup_with_path():
     """Check that DiodeClient.__init__() sets up the gRPC interceptor when a path is provided."""
     client = DiodeClient(


### PR DESCRIPTION
Set primary user agent composed with `{SDK_NAME SDK_VERSION} {PRODUCER_APP_NAME PRODUCER_APP_VERSION}`, i.e.

```
diode-sdk-python/0.0.1 my-producer/0.0.1 grpc-python/1.62.1 grpc-c/39.0.0 (osx; chttp2)
```