### PR TITLE
fix: use build semantic version

### DIFF
--- a/netboxlabs/diode/sdk/client.py
+++ b/netboxlabs/diode/sdk/client.py
@@ -13,10 +13,10 @@ import certifi
 import grpc
 import sentry_sdk
 
-from netboxlabs.diode.sdk.version import version_semver
 from netboxlabs.diode.sdk.diode.v1 import ingester_pb2, ingester_pb2_grpc
 from netboxlabs.diode.sdk.exceptions import DiodeClientError, DiodeConfigError
 from netboxlabs.diode.sdk.ingester import Entity
+from netboxlabs.diode.sdk.version import version_semver
 
 _DIODE_API_KEY_ENVVAR_NAME = "DIODE_API_KEY"
 _DIODE_SDK_LOG_LEVEL_ENVVAR_NAME = "DIODE_SDK_LOG_LEVEL"

--- a/netboxlabs/diode/sdk/client.py
+++ b/netboxlabs/diode/sdk/client.py
@@ -13,6 +13,7 @@ import certifi
 import grpc
 import sentry_sdk
 
+from netboxlabs.diode.sdk.version import version_semver
 from netboxlabs.diode.sdk.diode.v1 import ingester_pb2, ingester_pb2_grpc
 from netboxlabs.diode.sdk.exceptions import DiodeClientError, DiodeConfigError
 from netboxlabs.diode.sdk.ingester import Entity
@@ -69,7 +70,7 @@ class DiodeClient:
     """Diode Client."""
 
     _name = "diode-sdk-python"
-    _version = "0.0.1"
+    _version = version_semver()
     _app_name = None
     _app_version = None
     _channel = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,6 +19,7 @@ from netboxlabs.diode.sdk.client import (
     parse_target,
 )
 from netboxlabs.diode.sdk.exceptions import DiodeClientError, DiodeConfigError
+from netboxlabs.diode.sdk.version import version_semver
 
 
 def test_init():
@@ -31,7 +32,7 @@ def test_init():
     )
     assert config.target == "localhost:8081"
     assert config.name == "diode-sdk-python"
-    assert config.version == "0.0.1"
+    assert config.version == version_semver()
     assert config.app_name == "my-producer"
     assert config.app_version == "0.0.1"
     assert config.tls_verify is False
@@ -370,7 +371,7 @@ def test_client_properties_return_expected_values():
         api_key="abcde",
     )
     assert client.name == "diode-sdk-python"
-    assert client.version == "0.0.1"
+    assert client.version == version_semver()
     assert client.target == "localhost:8081"
     assert client.path == ""
     assert client.tls_verify is False


### PR DESCRIPTION
Instead of using semantic version set in the release build, client version used in the user agent been always set to `0.0.1`