### PR TITLE
feat: set entity timestamp (at source) if not provided

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*                     @leoparente @mfiedorowicz
+*                     @leoparente @ltucker @mfiedorowicz

--- a/netboxlabs/diode/sdk/ingester.py
+++ b/netboxlabs/diode/sdk/ingester.py
@@ -710,6 +710,11 @@ class Entity:
             virtual_machine, VirtualMachinePb, name=virtual_machine
         )
 
+        if timestamp is None:
+            ts = _timestamp_pb2.Timestamp()
+            ts.GetCurrentTime()
+            timestamp = ts
+
         return EntityPb(
             site=site,
             platform=platform,

--- a/tests/test_ingester.py
+++ b/tests/test_ingester.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # Copyright 2024 NetBox Labs Inc
 """NetBox Labs - Tests."""
+from google.protobuf import timestamp_pb2
 
 # ruff: noqa: I001
 from netboxlabs.diode.sdk.diode.v1.ingester_pb2 import (
@@ -656,6 +657,38 @@ def test_site_instantiation_with_all_fields():
     assert len(site.tags) == 2
     for tag in site.tags:
         assert isinstance(tag, TagPb)
+
+
+def test_entity_instantiation_with_no_timestamp_provided():
+    """Check Entity instantiation with no timestamp provided."""
+    entity = Entity(
+        site="Site1",
+    )
+    assert isinstance(entity, EntityPb)
+    assert isinstance(entity.site, SitePb)
+    assert entity.site.name == "Site1"
+    assert entity.timestamp is not None
+    assert entity.timestamp.seconds > 0
+    assert entity.timestamp.nanos > 0
+
+
+def test_entity_instantiation_with_timestamp_provided():
+    """Check Entity instantiation with timestamp provided."""
+    current_ts = timestamp_pb2.Timestamp()
+    current_ts.GetCurrentTime()
+
+    entity = Entity(
+        site="Site1",
+        timestamp=current_ts,
+    )
+    assert isinstance(entity, EntityPb)
+    assert isinstance(entity.site, SitePb)
+    assert entity.site.name == "Site1"
+    assert entity.timestamp is not None
+    assert entity.timestamp.seconds > 0
+    assert entity.timestamp.nanos > 0
+    assert entity.timestamp.seconds == current_ts.seconds
+    assert entity.timestamp.nanos == current_ts.nanos
 
 
 def test_entity_instantiation_with_site():


### PR DESCRIPTION
This pull request includes several changes to the `netboxlabs/diode/sdk/ingester.py` file, test coverage improvements in `tests/test_ingester.py`, and an update to the `.github/CODEOWNERS` file. The most important changes include adding a check for `None` timestamps, updating the code owners, and adding new test cases for entity instantiation.

### Codebase improvements:

* [`netboxlabs/diode/sdk/ingester.py`](diffhunk://#diff-e8bef1140f892ef75ddcc70590e5982cd78a4ef850ba4c55be0a9a6d2fca8e70R713-R717): Added a check to handle `None` timestamps by setting the current time if no timestamp is provided.

### Test coverage improvements:

* [`tests/test_ingester.py`](diffhunk://#diff-ea71527ff0962b9aee363ec3bd91240855c8152228e43b588a66f038af2b76ffR4): Added import for `timestamp_pb2` from `google.protobuf`.
* [`tests/test_ingester.py`](diffhunk://#diff-ea71527ff0962b9aee363ec3bd91240855c8152228e43b588a66f038af2b76ffR662-R693): Added a test case `test_entity_instantiation_with_no_timestamp_provided` to ensure that an entity is instantiated correctly when no timestamp is provided.
* [`tests/test_ingester.py`](diffhunk://#diff-ea71527ff0962b9aee363ec3bd91240855c8152228e43b588a66f038af2b76ffR662-R693): Added a test case `test_entity_instantiation_with_timestamp_provided` to validate entity instantiation with a provided timestamp.

### Code ownership:

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L1-R1): Updated the code owners to include `@ltucker` along with existing owners `@leoparente` and `@mfiedorowicz`.