### PR TITLE
feat: wrap exceptions thrown while authenticating

### DIFF
--- a/netboxlabs/diode/sdk/client.py
+++ b/netboxlabs/diode/sdk/client.py
@@ -237,7 +237,7 @@ class DiodeClient:
                         self._authenticate()
                         continue
                 raise DiodeClientError(err) from err
-        return RuntimeError("Max retries exceeded")
+        raise RuntimeError("Max retries exceeded")
 
     def _setup_sentry(self, dsn: str, traces_sample_rate: float, profiles_sample_rate: float):
         sentry_sdk.init(
@@ -289,8 +289,11 @@ class _DiodeAuthentication:
             }
         )
         url = self._get_auth_url()
-        conn.request("POST", url, data, headers)
-        response = conn.getresponse()
+        try:
+            conn.request("POST", url, data, headers)
+            response = conn.getresponse()
+        except Exception as e:
+            raise DiodeConfigError(f"Failed to obtain access token: {e}")
         if response.status != 200:
             raise DiodeConfigError(f"Failed to obtain access token: {response.reason}")
         token_info = json.loads(response.read().decode())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -588,6 +588,7 @@ def test_diode_authentication_failure(mock_diode_authentication):
             auth.authenticate()
         assert "Failed to obtain access token" in str(excinfo.value)
 
+
 @pytest.mark.parametrize("path", [
     "/diode",
     "",
@@ -611,4 +612,22 @@ def test_diode_authentication_url_with_path(mock_diode_authentication, path):
         mock_conn_instance.getresponse.return_value.read.return_value = json.dumps({"access_token": "mocked_token"}).encode()
         auth.authenticate()
         mock_conn_instance.request.assert_called_once_with("POST", f"{(path or '').rstrip('/')}/auth/token", mock.ANY, mock.ANY)
+
+
+def test_diode_authentication_request_exception(mock_diode_authentication):
+    """Test that an exception during the request raises a DiodeConfigError."""
+    auth = _DiodeAuthentication(
+        target="localhost:8081",
+        path="/diode",
+        tls_verify=False,
+        client_id="test_client_id",
+        client_secret="test_client_secret",
+    )
+    with mock.patch("http.client.HTTPConnection") as mock_http_conn:
+        mock_conn_instance = mock_http_conn.return_value
+        mock_conn_instance.request.side_effect = Exception("Connection error")
+
+        with pytest.raises(DiodeConfigError) as excinfo:
+            auth.authenticate()
+        assert "Failed to obtain access token: Connection error" in str(excinfo.value)
 


### PR DESCRIPTION
This pull request includes improvements to error handling and test coverage in the `netboxlabs/diode/sdk/client.py` file and its associated tests. The most important changes include replacing a `return` statement with a `raise` statement for consistency, adding exception handling during authentication, and introducing a new test to validate error handling for connection exceptions.

### Error handling improvements:
* Replaced `return RuntimeError` with `raise RuntimeError` in the `ingest` method to ensure proper exception handling. (`netboxlabs/diode/sdk/client.py`, [netboxlabs/diode/sdk/client.pyL240-R240](diffhunk://#diff-d7321aa83f5274dadf12aeab1b43eecc71c8e76d32add37792a05e76eac5e280L240-R240))
* Added a `try-except` block in the `authenticate` method to handle exceptions during the HTTP request and raise a `DiodeConfigError` with a meaningful message. (`netboxlabs/diode/sdk/client.py`, [netboxlabs/diode/sdk/client.pyR292-R296](diffhunk://#diff-d7321aa83f5274dadf12aeab1b43eecc71c8e76d32add37792a05e76eac5e280R292-R296))

### Test coverage enhancements:
* Added a new test, `test_diode_authentication_request_exception`, to verify that an exception during the HTTP request in the `authenticate` method raises a `DiodeConfigError` with the correct error message. (`tests/test_client.py`, [tests/test_client.pyR616-R633](diffhunk://#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110R616-R633))
* Minor formatting adjustments in the test file, such as removing extra blank lines. (`tests/test_client.py`, [tests/test_client.pyR591](diffhunk://#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110R591))