### PR TITLE
feat: Support HTTP schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ pip install netboxlabs-diode-sdk
 
 ### Example
 
-* `target` should be the address of the Diode service, e.g. `grpc://localhost:8080/diode` for insecure connection
-  or `grpcs://example.com` for secure connection.
+* `target` should be the address of the Diode service.
+  * Insecure connections: `grpc://localhost:8080/diode` or `http://localhost:8080/diode`
+  * Secure connections: `grpcs://example.com` or `https://example.com`
 
 ```python
 from netboxlabs.diode.sdk import DiodeClient

--- a/netboxlabs/diode/sdk/client.py
+++ b/netboxlabs/diode/sdk/client.py
@@ -98,7 +98,7 @@ def _get_required_config_value(env_var_name: str, value: str | None = None) -> s
 
 
 def _get_optional_config_value(
-        env_var_name: str, value: str | None = None
+    env_var_name: str, value: str | None = None
 ) -> str | None:
     """Get optional config value either from provided value or environment variable."""
     if value is None:
@@ -117,16 +117,16 @@ class DiodeClient(DiodeClientInterface):
     _stub = None
 
     def __init__(
-            self,
-            target: str,
-            app_name: str,
-            app_version: str,
-            client_id: str | None = None,
-            client_secret: str | None = None,
-            sentry_dsn: str = None,
-            sentry_traces_sample_rate: float = 1.0,
-            sentry_profiles_sample_rate: float = 1.0,
-            max_auth_retries: int = 3,
+        self,
+        target: str,
+        app_name: str,
+        app_version: str,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        sentry_dsn: str = None,
+        sentry_traces_sample_rate: float = 1.0,
+        sentry_profiles_sample_rate: float = 1.0,
+        max_auth_retries: int = 3,
     ):
         """Initiate a new client."""
         log_level = os.getenv(_DIODE_SDK_LOG_LEVEL_ENVVAR_NAME, "INFO").upper()
@@ -251,9 +251,9 @@ class DiodeClient(DiodeClientInterface):
         self._channel.close()
 
     def ingest(
-            self,
-            entities: Iterable[Entity | ingester_pb2.Entity | None],
-            stream: str | None = _DEFAULT_STREAM,
+        self,
+        entities: Iterable[Entity | ingester_pb2.Entity | None],
+        stream: str | None = _DEFAULT_STREAM,
     ) -> ingester_pb2.IngestResponse:
         """Ingest entities."""
         for attempt in range(self._max_auth_retries):
@@ -384,13 +384,13 @@ class DiodeDryRunClient(DiodeClientInterface):
 
 class _DiodeAuthentication:
     def __init__(
-            self,
-            target: str,
-            path: str,
-            tls_verify: bool,
-            client_id: str,
-            client_secret: str,
-            scope: str,
+        self,
+        target: str,
+        path: str,
+        tls_verify: bool,
+        client_id: str,
+        client_secret: str,
+        scope: str,
     ):
         self._target = target
         self._tls_verify = tls_verify
@@ -448,12 +448,12 @@ class _ClientCallDetails(
     collections.namedtuple(
         "_ClientCallDetails",
         (
-                "method",
-                "timeout",
-                "metadata",
-                "credentials",
-                "wait_for_ready",
-                "compression",
+            "method",
+            "timeout",
+            "metadata",
+            "credentials",
+            "wait_for_ready",
+            "compression",
         ),
     ),
     grpc.ClientCallDetails,
@@ -508,7 +508,7 @@ class DiodeMethodClientInterceptor(
         return self._intercept_call(continuation, client_call_details, request)
 
     def intercept_stream_unary(
-            self, continuation, client_call_details, request_iterator
+        self, continuation, client_call_details, request_iterator
     ):
         """Intercept stream unary."""
         return self._intercept_call(continuation, client_call_details, request_iterator)

--- a/netboxlabs/diode/sdk/client.py
+++ b/netboxlabs/diode/sdk/client.py
@@ -64,7 +64,7 @@ def parse_target(target: str) -> tuple[str, str, bool]:
     parsed_target = urlparse(target)
 
     if parsed_target.scheme not in ["grpc", "grpcs", "http", "https"]:
-        raise ValueError("target should start with grpc:// or grpcs://")
+        raise ValueError("target should start with grpc:// or grpcs:// or http:// or https://")
 
     tls_verify = parsed_target.scheme in ["grpcs", "https"]
 

--- a/netboxlabs/diode/sdk/client.py
+++ b/netboxlabs/diode/sdk/client.py
@@ -63,15 +63,18 @@ def parse_target(target: str) -> tuple[str, str, bool]:
     """Parse the target into authority, path and tls_verify."""
     parsed_target = urlparse(target)
 
-    if parsed_target.scheme not in ["grpc", "grpcs"]:
+    if parsed_target.scheme not in ["grpc", "grpcs", "http", "https"]:
         raise ValueError("target should start with grpc:// or grpcs://")
 
-    tls_verify = parsed_target.scheme == "grpcs"
+    tls_verify = parsed_target.scheme in ["grpcs", "https"]
 
     authority = parsed_target.netloc
 
     if ":" not in authority:
-        authority += ":443"
+        if parsed_target.scheme in ["grpc", "http"]:
+            authority += ":80"
+        elif parsed_target.scheme in ["grpcs", "https"]:
+            authority += ":443"
 
     return authority, parsed_target.path, tls_verify
 
@@ -95,7 +98,7 @@ def _get_required_config_value(env_var_name: str, value: str | None = None) -> s
 
 
 def _get_optional_config_value(
-    env_var_name: str, value: str | None = None
+        env_var_name: str, value: str | None = None
 ) -> str | None:
     """Get optional config value either from provided value or environment variable."""
     if value is None:
@@ -114,16 +117,16 @@ class DiodeClient(DiodeClientInterface):
     _stub = None
 
     def __init__(
-        self,
-        target: str,
-        app_name: str,
-        app_version: str,
-        client_id: str | None = None,
-        client_secret: str | None = None,
-        sentry_dsn: str = None,
-        sentry_traces_sample_rate: float = 1.0,
-        sentry_profiles_sample_rate: float = 1.0,
-        max_auth_retries: int = 3,
+            self,
+            target: str,
+            app_name: str,
+            app_version: str,
+            client_id: str | None = None,
+            client_secret: str | None = None,
+            sentry_dsn: str = None,
+            sentry_traces_sample_rate: float = 1.0,
+            sentry_profiles_sample_rate: float = 1.0,
+            max_auth_retries: int = 3,
     ):
         """Initiate a new client."""
         log_level = os.getenv(_DIODE_SDK_LOG_LEVEL_ENVVAR_NAME, "INFO").upper()
@@ -248,9 +251,9 @@ class DiodeClient(DiodeClientInterface):
         self._channel.close()
 
     def ingest(
-        self,
-        entities: Iterable[Entity | ingester_pb2.Entity | None],
-        stream: str | None = _DEFAULT_STREAM,
+            self,
+            entities: Iterable[Entity | ingester_pb2.Entity | None],
+            stream: str | None = _DEFAULT_STREAM,
     ) -> ingester_pb2.IngestResponse:
         """Ingest entities."""
         for attempt in range(self._max_auth_retries):
@@ -277,7 +280,7 @@ class DiodeClient(DiodeClientInterface):
         raise RuntimeError("Max retries exceeded")
 
     def _setup_sentry(
-        self, dsn: str, traces_sample_rate: float, profiles_sample_rate: float
+            self, dsn: str, traces_sample_rate: float, profiles_sample_rate: float
     ):
         sentry_sdk.init(
             dsn=dsn,
@@ -349,9 +352,9 @@ class DiodeDryRunClient(DiodeClientInterface):
         """Exits the runtime context related to the channel object."""
 
     def ingest(
-        self,
-        entities: Iterable[Entity | ingester_pb2.Entity | None],
-        stream: str | None = _DEFAULT_STREAM,
+            self,
+            entities: Iterable[Entity | ingester_pb2.Entity | None],
+            stream: str | None = _DEFAULT_STREAM,
     ) -> ingester_pb2.IngestResponse:
         """Ingest entities in dry run mode."""
         request = ingester_pb2.IngestRequest(
@@ -381,13 +384,13 @@ class DiodeDryRunClient(DiodeClientInterface):
 
 class _DiodeAuthentication:
     def __init__(
-        self,
-        target: str,
-        path: str,
-        tls_verify: bool,
-        client_id: str,
-        client_secret: str,
-        scope: str,
+            self,
+            target: str,
+            path: str,
+            tls_verify: bool,
+            client_id: str,
+            client_secret: str,
+            scope: str,
     ):
         self._target = target
         self._tls_verify = tls_verify
@@ -445,12 +448,12 @@ class _ClientCallDetails(
     collections.namedtuple(
         "_ClientCallDetails",
         (
-            "method",
-            "timeout",
-            "metadata",
-            "credentials",
-            "wait_for_ready",
-            "compression",
+                "method",
+                "timeout",
+                "metadata",
+                "credentials",
+                "wait_for_ready",
+                "compression",
         ),
     ),
     grpc.ClientCallDetails,
@@ -505,7 +508,7 @@ class DiodeMethodClientInterceptor(
         return self._intercept_call(continuation, client_call_details, request)
 
     def intercept_stream_unary(
-        self, continuation, client_call_details, request_iterator
+            self, continuation, client_call_details, request_iterator
     ):
         """Intercept stream unary."""
         return self._intercept_call(continuation, client_call_details, request_iterator)

--- a/netboxlabs/diode/sdk/client.py
+++ b/netboxlabs/diode/sdk/client.py
@@ -195,7 +195,7 @@ class DiodeClient(DiodeClientInterface):
         if self._sentry_dsn is not None:
             _LOGGER.debug("Setting up Sentry")
             self._setup_sentry(
-                self._sentry_dsn, sentry_traces_sample_rate, sentry_profiles_sample_rate
+            self._sentry_dsn, sentry_traces_sample_rate, sentry_profiles_sample_rate
             )
 
     @property

--- a/netboxlabs/diode/sdk/client.py
+++ b/netboxlabs/diode/sdk/client.py
@@ -352,9 +352,9 @@ class DiodeDryRunClient(DiodeClientInterface):
         """Exits the runtime context related to the channel object."""
 
     def ingest(
-            self,
-            entities: Iterable[Entity | ingester_pb2.Entity | None],
-            stream: str | None = _DEFAULT_STREAM,
+        self,
+        entities: Iterable[Entity | ingester_pb2.Entity | None],
+        stream: str | None = _DEFAULT_STREAM,
     ) -> ingester_pb2.IngestResponse:
         """Ingest entities in dry run mode."""
         request = ingester_pb2.IngestRequest(

--- a/netboxlabs/diode/sdk/client.py
+++ b/netboxlabs/diode/sdk/client.py
@@ -195,7 +195,7 @@ class DiodeClient(DiodeClientInterface):
         if self._sentry_dsn is not None:
             _LOGGER.debug("Setting up Sentry")
             self._setup_sentry(
-            self._sentry_dsn, sentry_traces_sample_rate, sentry_profiles_sample_rate
+                self._sentry_dsn, sentry_traces_sample_rate, sentry_profiles_sample_rate
             )
 
     @property
@@ -280,7 +280,7 @@ class DiodeClient(DiodeClientInterface):
         raise RuntimeError("Max retries exceeded")
 
     def _setup_sentry(
-            self, dsn: str, traces_sample_rate: float, profiles_sample_rate: float
+        self, dsn: str, traces_sample_rate: float, profiles_sample_rate: float
     ):
         sentry_sdk.init(
             dsn=dsn,

--- a/netboxlabs/diode/sdk/client.py
+++ b/netboxlabs/diode/sdk/client.py
@@ -64,7 +64,7 @@ def parse_target(target: str) -> tuple[str, str, bool]:
     parsed_target = urlparse(target)
 
     if parsed_target.scheme not in ["grpc", "grpcs", "http", "https"]:
-        raise ValueError("target should start with grpc:// or grpcs:// or http:// or https://")
+        raise ValueError("target should start with grpc://, grpcs://, http:// or https://")
 
     tls_verify = parsed_target.scheme in ["grpcs", "https"]
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -143,7 +143,13 @@ def test_parse_target_handles_no_path():
 
 def test_parse_target_parses_tls_verify_correctly():
     """Check that parse_target parses tls_verify correctly."""
+    _, _, tls_verify = parse_target("grpc://localhost:8081")
+    assert tls_verify is False
+    _, _, tls_verify = parse_target("http://localhost:8081")
+    assert tls_verify is False
     _, _, tls_verify = parse_target("grpcs://localhost:8081")
+    assert tls_verify is True
+    _, _, tls_verify = parse_target("https://localhost:8081")
     assert tls_verify is True
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -103,6 +103,12 @@ def test_load_certs_returns_bytes():
     """Check that _load_certs returns bytes."""
     assert isinstance(_load_certs(), bytes)
 
+
+def test_parse_target_handles_ftp_prefix():
+    """Check that parse_target raises an error when the target contains ftp://."""
+    with pytest.raises(ValueError):
+        parse_target("ftp://localhost:8081")
+
 def test_parse_target_parses_authority_correctly():
     """Check that parse_target parses the authority correctly."""
     authority, path, tls_verify = parse_target("grpc://localhost:8081")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -103,19 +103,6 @@ def test_load_certs_returns_bytes():
     """Check that _load_certs returns bytes."""
     assert isinstance(_load_certs(), bytes)
 
-
-def test_parse_target_handles_http_prefix():
-    """Check that parse_target raises an error when the target contains http://."""
-    with pytest.raises(ValueError):
-        parse_target("http://localhost:8081")
-
-
-def test_parse_target_handles_https_prefix():
-    """Check that parse_target raises an error when the target contains https://."""
-    with pytest.raises(ValueError):
-        parse_target("https://localhost:8081")
-
-
 def test_parse_target_parses_authority_correctly():
     """Check that parse_target parses the authority correctly."""
     authority, path, tls_verify = parse_target("grpc://localhost:8081")
@@ -127,6 +114,12 @@ def test_parse_target_parses_authority_correctly():
 def test_parse_target_adds_default_port_if_missing():
     """Check that parse_target adds the default port if missing."""
     authority, _, _ = parse_target("grpc://localhost")
+    assert authority == "localhost:80"
+    authority, _, _ = parse_target("http://localhost")
+    assert authority == "localhost:80"
+    authority, _, _ = parse_target("grpcs://localhost")
+    assert authority == "localhost:443"
+    authority, _, _ = parse_target("https://localhost")
     assert authority == "localhost:443"
 
 


### PR DESCRIPTION
This pull request updates the Diode SDK to support both gRPC and HTTP(S) connection schemes, improving flexibility for users. The main changes clarify usage in the documentation and enhance the connection parsing logic to handle more schemes and default ports.

**Documentation improvements:**

* Updated the `README.md` to explain that `target` can use `grpc://`, `grpcs://`, `http://`, or `https://` schemes, with examples for both insecure and secure connections.

**Connection parsing enhancements:**

* Modified `parse_target` in `client.py` to accept `http` and `https` schemes in addition to `grpc` and `grpcs`, and updated the error message accordingly.
* Adjusted the default port assignment in `parse_target` to use `:80` for `grpc` and `http`, and `:443` for `grpcs` and `https`.
* Changed TLS verification logic to enable it for both `grpcs` and `https` schemes.