### PR TITLE
chore: upgrade semantic release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,7 +100,7 @@ jobs:
               ]
             }
       - name: setup semantic-release
-        run: npm i
+        run: npm install --legacy-peer-deps
       - name: release dry-run
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_SEMANTIC_RELEASE_WEBHOOK }}
@@ -240,7 +240,7 @@ jobs:
               ]
             }
       - name: setup semantic-release
-        run: npm i
+        run: npm install --legacy-peer-deps
       - name: Release
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_OBSERVABILITY_RELEASE_WEBHOOK }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,6 +54,7 @@ jobs:
               "version": "1.0.0",
               "devDependencies": {
                 "semantic-release-export-data": "^1.0.1",
+                "semantic-release": "25.0.0-beta.6",
                 "@semantic-release/changelog": "^6.0.3"
               }
             }
@@ -193,6 +194,7 @@ jobs:
               "version": "1.0.0",
               "devDependencies": {
                 "semantic-release-export-data": "^1.0.1",
+                "semantic-release": "25.0.0-beta.6",
                 "@semantic-release/changelog": "^6.0.3"
               }
             }


### PR DESCRIPTION
This pull request updates the release workflow configuration to improve compatibility with dependencies and ensure the correct version of `semantic-release` is used. The main changes involve updating the installation command and specifying a beta version of `semantic-release`.

**Dependency management improvements:**

* Updated the `devDependencies` in two places to explicitly use `semantic-release` version `25.0.0-beta.6`, ensuring consistent release tooling across jobs. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR57) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR197)

**Workflow compatibility fixes:**

* Changed the npm install command from `npm i` to `npm install --legacy-peer-deps` in both release jobs to avoid peer dependency conflicts during setup. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL102-R103) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL241-R243)