### PR TITLE
fix(gha): use underscores in Python package name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ env:
   SEMANTIC_RELEASE_PACKAGE: ${{ github.repository }}
   PYTHON_RUNTIME_VERSION: "3.11"
   APP_NAME: diode-sdk-python
-  PYTHON_PACKAGE_NAME: netboxlabs-diode-sdk
+  PYTHON_PACKAGE_NAME: netboxlabs_diode_sdk
 
 permissions:
   id-token: write
@@ -157,10 +157,6 @@ jobs:
           cat pyproject.toml | grep version
           python3 -m pip install --upgrade build
           python3 -m build --sdist --outdir dist/
-      - name: Replace underscores with hyphens in build filename
-        run: |
-          BUILD_FILENAME=$(ls dist/ | grep tar.gz)
-          mv dist/$BUILD_FILENAME dist/${{ env.OUTPUT_FILENAME }}
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This pull request updates the release workflow for the Python SDK to use the correct package naming convention and simplifies the build process by removing unnecessary filename renaming steps.

**Workflow improvements:**

* Changed the `PYTHON_PACKAGE_NAME` environment variable in `.github/workflows/release.yaml` from `netboxlabs-diode-sdk` to `netboxlabs_diode_sdk` to use underscores instead of hyphens, aligning with Python package naming conventions.

**Build process simplification:**

* Removed the step that replaced underscores with hyphens in the build filename, as this is no longer needed due to the updated package name format.