### PR TITLE
fix: loosen gRPC DNS error message assertion in test_client_error

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -87,7 +87,7 @@ def test_client_error(mock_diode_authentication):
         )
         client.ingest(entities=[])
     assert err.value.status_code == grpc.StatusCode.UNAVAILABLE
-    assert "DNS resolution failed for invalid:8081" in err.value.details
+    assert "invalid:8081" in err.value.details
 
 
 def test_diode_client_error_repr_returns_correct_string():


### PR DESCRIPTION
## Summary
- Loosens the `test_client_error` assertion to check for `"invalid:8081"` in gRPC error details instead of a specific DNS error message format
- The gRPC DNS error message format changed across versions, causing the test to fail despite the underlying behavior being correct

## Test plan
- [x] Run `pytest tests/test_client.py::test_client_error` and verify it passes
- [x] Confirm the assertion still validates that the error references the expected host

Resolves OBS-2681