### PR TITLE
feat(OBS-2873): add gRPC client keepalive configuration

### DIFF
--- a/netboxlabs/diode/sdk/client.py
+++ b/netboxlabs/diode/sdk/client.py
@@ -146,7 +146,8 @@ def _get_optional_config_value(
 
 
 def _otlp_grpc_channel_options(primary_user_agent_value: str) -> list[tuple[str, Any]]:
-    """gRPC channel options for generic OTLP collectors (user-agent only).
+    """
+    Build gRPC channel argument list for generic OTLP collectors (user-agent only).
 
     Avoid aggressive HTTP/2 keepalive here: many OTLP backends enforce strict ping
     limits and may GOAWAY idle exporters when permit-without-stream or unlimited
@@ -158,7 +159,7 @@ def _otlp_grpc_channel_options(primary_user_agent_value: str) -> list[tuple[str,
 
 
 def _diode_ingest_grpc_channel_options(primary_user_agent_value: str) -> list[tuple[str, Any]]:
-    """gRPC channel options for the Diode ingester API (keepalive-friendly servers)."""
+    """Build gRPC channel argument list for the Diode ingester API (with keepalive)."""
     return _otlp_grpc_channel_options(primary_user_agent_value) + [
         ("grpc.keepalive_time_ms", _GRPC_KEEPALIVE_TIME_MS),
         ("grpc.keepalive_timeout_ms", _GRPC_KEEPALIVE_TIMEOUT_MS),

--- a/netboxlabs/diode/sdk/client.py
+++ b/netboxlabs/diode/sdk/client.py
@@ -50,7 +50,6 @@ _DRY_RUN_OUTPUT_DIR_ENVVAR_NAME = "DIODE_DRY_RUN_OUTPUT_DIR"
 _INGEST_SCOPE = "diode:ingest"
 _LOGGER = logging.getLogger(__name__)
 _MAX_RETRIES_ENVVAR_NAME = "DIODE_MAX_AUTH_RETRIES"
-# HTTP/2 keepalive: align with netbox-assurance-plugin (ENGHLP-1220) and diode-pro
 # server policy (MinTime 10s so client pings must be >= 10s, e.g. 30s interval).
 _GRPC_KEEPALIVE_TIME_MS = 30_000
 _GRPC_KEEPALIVE_TIMEOUT_MS = 10_000

--- a/netboxlabs/diode/sdk/client.py
+++ b/netboxlabs/diode/sdk/client.py
@@ -50,6 +50,13 @@ _DRY_RUN_OUTPUT_DIR_ENVVAR_NAME = "DIODE_DRY_RUN_OUTPUT_DIR"
 _INGEST_SCOPE = "diode:ingest"
 _LOGGER = logging.getLogger(__name__)
 _MAX_RETRIES_ENVVAR_NAME = "DIODE_MAX_AUTH_RETRIES"
+# HTTP/2 keepalive: align with netbox-assurance-plugin (ENGHLP-1220) and diode-pro
+# server policy (MinTime 10s so client pings must be >= 10s, e.g. 30s interval).
+_GRPC_KEEPALIVE_TIME_MS = 30_000
+_GRPC_KEEPALIVE_TIMEOUT_MS = 10_000
+_GRPC_KEEPALIVE_PERMIT_WITHOUT_CALLS = 1
+# 0 = no cap on keepalive pings without data (matches reconciler Python client).
+_GRPC_HTTP2_MAX_PINGS_WITHOUT_DATA = 0
 
 
 def load_dryrun_entities(file_path: str | Path) -> Iterable[Entity]:
@@ -136,6 +143,20 @@ def _get_optional_config_value(
     if value is None:
         value = os.getenv(env_var_name)
     return value
+
+
+def _base_grpc_channel_options(primary_user_agent_value: str) -> list[tuple[str, Any]]:
+    """grpc channel options shared by Diode clients: user-agent and keepalive."""
+    return [
+        ("grpc.primary_user_agent", primary_user_agent_value),
+        ("grpc.keepalive_time_ms", _GRPC_KEEPALIVE_TIME_MS),
+        ("grpc.keepalive_timeout_ms", _GRPC_KEEPALIVE_TIMEOUT_MS),
+        (
+            "grpc.keepalive_permit_without_calls",
+            _GRPC_KEEPALIVE_PERMIT_WITHOUT_CALLS,
+        ),
+        ("grpc.http2.max_pings_without_data", _GRPC_HTTP2_MAX_PINGS_WITHOUT_DATA),
+    ]
 
 
 def _get_proxy_env_var(var_name: str) -> str | None:
@@ -335,12 +356,9 @@ class DiodeClient(DiodeClientInterface):
 
         self._authenticate(_INGEST_SCOPE)
 
-        channel_opts = [
-            (
-                "grpc.primary_user_agent",
-                f"{self._name}/{self._version} {self._app_name}/{self._app_version}",
-            ),
-        ]
+        channel_opts = _base_grpc_channel_options(
+            f"{self._name}/{self._version} {self._app_name}/{self._app_version}"
+        )
 
         proxy_url = _get_grpc_proxy_url(self._target, self._tls_verify)
         if proxy_url:
@@ -631,12 +649,9 @@ class DiodeOTLPClient(DiodeClientInterface):
             else None
         )
 
-        channel_opts = [
-            (
-                "grpc.primary_user_agent",
-                f"{self._name}/{self._version} {self._app_name}/{self._app_version}",
-            ),
-        ]
+        channel_opts = _base_grpc_channel_options(
+            f"{self._name}/{self._version} {self._app_name}/{self._app_version}"
+        )
 
         proxy_url = _get_grpc_proxy_url(self._target, self._tls_verify)
         if proxy_url:

--- a/netboxlabs/diode/sdk/client.py
+++ b/netboxlabs/diode/sdk/client.py
@@ -145,10 +145,21 @@ def _get_optional_config_value(
     return value
 
 
-def _base_grpc_channel_options(primary_user_agent_value: str) -> list[tuple[str, Any]]:
-    """grpc channel options shared by Diode clients: user-agent and keepalive."""
+def _otlp_grpc_channel_options(primary_user_agent_value: str) -> list[tuple[str, Any]]:
+    """gRPC channel options for generic OTLP collectors (user-agent only).
+
+    Avoid aggressive HTTP/2 keepalive here: many OTLP backends enforce strict ping
+    limits and may GOAWAY idle exporters when permit-without-stream or unlimited
+    pings are enabled.
+    """
     return [
         ("grpc.primary_user_agent", primary_user_agent_value),
+    ]
+
+
+def _diode_ingest_grpc_channel_options(primary_user_agent_value: str) -> list[tuple[str, Any]]:
+    """gRPC channel options for the Diode ingester API (keepalive-friendly servers)."""
+    return _otlp_grpc_channel_options(primary_user_agent_value) + [
         ("grpc.keepalive_time_ms", _GRPC_KEEPALIVE_TIME_MS),
         ("grpc.keepalive_timeout_ms", _GRPC_KEEPALIVE_TIMEOUT_MS),
         (
@@ -356,7 +367,7 @@ class DiodeClient(DiodeClientInterface):
 
         self._authenticate(_INGEST_SCOPE)
 
-        channel_opts = _base_grpc_channel_options(
+        channel_opts = _diode_ingest_grpc_channel_options(
             f"{self._name}/{self._version} {self._app_name}/{self._app_version}"
         )
 
@@ -649,7 +660,7 @@ class DiodeOTLPClient(DiodeClientInterface):
             else None
         )
 
-        channel_opts = _base_grpc_channel_options(
+        channel_opts = _otlp_grpc_channel_options(
             f"{self._name}/{self._version} {self._app_name}/{self._app_version}"
         )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -18,7 +18,8 @@ from netboxlabs.diode.sdk.client import (
     DiodeMethodClientInterceptor,
     DiodeOTLPClient,
     _ClientCallDetails,
-    _base_grpc_channel_options,
+    _diode_ingest_grpc_channel_options,
+    _otlp_grpc_channel_options,
     _DiodeAuthentication,
     _get_sentry_dsn,
     _load_certs,
@@ -270,7 +271,7 @@ def test_insecure_channel_options_with_primary_user_agent(mock_diode_authenticat
         mock_insecure_channel.assert_called_once()
         _, kwargs = mock_insecure_channel.call_args
         assert kwargs["options"] == tuple(
-            _base_grpc_channel_options(
+            _diode_ingest_grpc_channel_options(
                 f"{client.name}/{client.version} {client.app_name}/{client.app_version}"
             )
         )
@@ -290,7 +291,7 @@ def test_secure_channel_options_with_primary_user_agent(mock_diode_authenticatio
         mock_secure_channel.assert_called_once()
         _, kwargs = mock_secure_channel.call_args
         assert kwargs["options"] == tuple(
-            _base_grpc_channel_options(
+            _diode_ingest_grpc_channel_options(
                 f"{client.name}/{client.version} {client.app_name}/{client.app_version}"
             )
         )
@@ -881,6 +882,30 @@ def test_otlp_client_grpcs_uses_secure_channel():
 
         client.close()
         base_channel.close.assert_called_once()
+
+
+def test_otlp_insecure_channel_options_exclude_diode_keepalive():
+    """OTLP targets arbitrary collectors; only user-agent is forced (Codex/OBS-2873)."""
+    with (
+        patch("netboxlabs.diode.sdk.client.grpc.insecure_channel") as mock_insecure,
+        patch("netboxlabs.diode.sdk.client.logs_service_pb2_grpc.LogsServiceStub"),
+    ):
+        client = DiodeOTLPClient(
+            target="grpc://collector:4317",
+            app_name="orb-producer",
+            app_version="1.2.3",
+        )
+
+        mock_insecure.assert_called_once()
+        _, kwargs = mock_insecure.call_args
+        ua = (
+            f"{client.name}/{client.version} "
+            f"{client.app_name}/{client.app_version}"
+        )
+        assert kwargs["options"] == tuple(_otlp_grpc_channel_options(ua))
+        assert all(
+            opt[0] != "grpc.keepalive_time_ms" for opt in kwargs["options"]
+        )
 
 
 def test_diode_authentication_with_custom_certificates():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,10 +19,10 @@ from netboxlabs.diode.sdk.client import (
     DiodeOTLPClient,
     _ClientCallDetails,
     _diode_ingest_grpc_channel_options,
-    _otlp_grpc_channel_options,
     _DiodeAuthentication,
     _get_sentry_dsn,
     _load_certs,
+    _otlp_grpc_channel_options,
     load_dryrun_entities,
     parse_target,
 )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -18,6 +18,7 @@ from netboxlabs.diode.sdk.client import (
     DiodeMethodClientInterceptor,
     DiodeOTLPClient,
     _ClientCallDetails,
+    _base_grpc_channel_options,
     _DiodeAuthentication,
     _get_sentry_dsn,
     _load_certs,
@@ -268,11 +269,10 @@ def test_insecure_channel_options_with_primary_user_agent(mock_diode_authenticat
 
         mock_insecure_channel.assert_called_once()
         _, kwargs = mock_insecure_channel.call_args
-        assert kwargs["options"] == (
-            (
-                "grpc.primary_user_agent",
-                f"{client.name}/{client.version} {client.app_name}/{client.app_version}",
-            ),
+        assert kwargs["options"] == tuple(
+            _base_grpc_channel_options(
+                f"{client.name}/{client.version} {client.app_name}/{client.app_version}"
+            )
         )
 
 
@@ -289,11 +289,10 @@ def test_secure_channel_options_with_primary_user_agent(mock_diode_authenticatio
 
         mock_secure_channel.assert_called_once()
         _, kwargs = mock_secure_channel.call_args
-        assert kwargs["options"] == (
-            (
-                "grpc.primary_user_agent",
-                f"{client.name}/{client.version} {client.app_name}/{client.app_version}",
-            ),
+        assert kwargs["options"] == tuple(
+            _base_grpc_channel_options(
+                f"{client.name}/{client.version} {client.app_name}/{client.app_version}"
+            )
         )
 
 


### PR DESCRIPTION
## Summary
This change adds HTTP/2 keepalive channel options for **`DiodeClient`** (ingester) so idle connections to the Diode API are less likely to be reset by intermediaries.

**`DiodeOTLPClient`** targets arbitrary OTLP collectors and therefore uses **user-agent-only** gRPC channel options (no keepalive / `max_pings_without_data`): many collectors enforce strict ping limits and can `GOAWAY` idle exporters otherwise.

## What changed
- **`_diode_ingest_grpc_channel_options`**: `grpc.primary_user_agent` plus `grpc.keepalive_time_ms`, `grpc.keepalive_timeout_ms`, `grpc.keepalive_permit_without_calls`, and `grpc.http2.max_pings_without_data` (parity with netbox-assurance-plugin reconciler client where that stack talks to Diode-tolerant servers, ENGHLP-1220).
- **`_otlp_grpc_channel_options`**: `grpc.primary_user_agent` only for OTLP.
- `DiodeClient` uses the ingester helper; `DiodeOTLPClient` uses the OTLP helper; proxy and SSL-related options are unchanged.
- Tests cover ingester options via `_diode_ingest_grpc_channel_options` and assert OTLP channels exclude keepalive.

## How tested
- `pytest` (full suite).