### PR TITLE
docs(readme): link to docs/examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ if __name__ == "__main__":
 
 ```
 
+See [`docs/examples/`](./docs/examples) for per-entity examples (one file per supported NetBox object type).
+
 ### Using Metadata
 
 Entities support attaching custom metadata as key-value pairs. Metadata can be used to store additional context, tracking information, or custom attributes that don't fit into the standard NetBox fields.


### PR DESCRIPTION
## Summary

Closes the second half of [#74](https://github.com/netboxlabs/diode-sdk-python/issues/74).

The original report (Dec 2025) flagged a broken `[examples](./examples)` link in the README pointing at a non-existent directory. The broken link itself was removed during the v1.10.x README restructure (#78), and #83 later added a real `docs/examples/` directory — but the README was never updated to point at it, so readers still have no in-README path to the example catalog.

This adds a one-line pointer at the exact anchor location the original broken link occupied (right after the basic Example code block).

## Change

```diff
 if __name__ == "__main__":
     main()
 ```

+See [`docs/examples/`](./docs/examples) for per-entity examples (one file per supported NetBox object type).
+
 ### Using Metadata
```

## Test plan
- [x] Relative link `./docs/examples` resolves (directory exists with one `.py` per entity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)