### PR TITLE
docs(readme): sync Supported entities list with docs/examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,10 @@ These attributes are added alongside standard OTLP resource attributes (`service
 * ASN
 * ASN Range
 * Aggregate
+* Cable
+* Cable Bundle
+* Cable Path
+* Cable Termination
 * Circuit
 * Circuit Group
 * Circuit Group Assignment
@@ -518,8 +522,12 @@ These attributes are added alongside standard OTLP resource attributes (`service
 * Contact Assignment
 * Contact Group
 * Contact Role
+* Custom Field
+* Custom Field Choice Set
+* Custom Link
 * Device
 * Device Bay
+* Device Config
 * Device Role
 * Device Type
 * FHRP Group
@@ -535,6 +543,7 @@ These attributes are added alongside standard OTLP resource attributes (`service
 * Interface
 * Inventory Item
 * Inventory Item Role
+* Journal Entry
 * L2VPN
 * L2VPN Termination
 * Location
@@ -543,6 +552,9 @@ These attributes are added alongside standard OTLP resource attributes (`service
 * Module
 * Module Bay
 * Module Type
+* Module Type Profile
+* Owner
+* Owner Group
 * Platform
 * Power Feed
 * Power Outlet
@@ -554,12 +566,15 @@ These attributes are added alongside standard OTLP resource attributes (`service
 * Provider Network
 * RIR
 * Rack
+* Rack Group
+* Rack Reservation
 * Rack Role
 * Rack Type
 * Rear Port
 * Region
 * Role
 * Route Target
+* Script Module
 * Service
 * Site
 * Site Group
@@ -582,6 +597,7 @@ These attributes are added alongside standard OTLP resource attributes (`service
 * Virtual Device Context
 * Virtual Disk
 * Virtual Machine
+* Virtual Machine Type
 * Wireless Lan
 * Wireless Lan Group
 * Wireless Link


### PR DESCRIPTION
## Summary

The README's **Supported entities (object types)** list had drifted behind the
per-entity examples in [`docs/examples/`](./docs/examples). This syncs the list
so it matches the examples exactly.

## What changes

Adds the **16** object types that have a `docs/examples/` file (and are `Entity`
oneof members) but were missing from the README list:

`Cable`, `Cable Bundle`, `Cable Path`, `Cable Termination`, `Custom Field`,
`Custom Field Choice Set`, `Custom Link`, `Device Config`, `Journal Entry`,
`Module Type Profile`, `Owner`, `Owner Group`, `Rack Group`, `Rack Reservation`,
`Script Module`, `Virtual Machine Type`.

Inserted in the existing alphabetical positions. Docs-only change.

## Verification

- The list now matches `docs/examples/` **1:1** — 100 object types, no extras,
  none missing (verified by canonicalized set comparison).
- Every added entry is a member of the `Entity` proto oneof (i.e. a real
  ingestable object type, not a usage-only example).
- Nothing removed: the previous list was a strict subset of the examples.
