### PR TITLE
fix(ingester): don't clear a cluster's scope oneof when building a VirtualMachine

### DIFF
--- a/netboxlabs/diode/sdk/ingester.py
+++ b/netboxlabs/diode/sdk/ingester.py
@@ -7007,7 +7007,10 @@ class VirtualMachine:
         if site is not None:
             if device is not None and not device.HasField("site"):
                 device.site.CopyFrom(site)
-            if cluster is not None and not cluster.HasField("scope_site"):
+            # scope_site shares a oneof with scope_location/region/site_group, so
+            # HasField("scope_site") is False while a sibling holds the scope and
+            # CopyFrom would silently clear it.
+            if cluster is not None and not cluster.WhichOneof("scope"):
                 cluster.scope_site.CopyFrom(site)
         if role is not None:
             if device is not None and not device.HasField("role"):

--- a/tests/test_ingester.py
+++ b/tests/test_ingester.py
@@ -43,6 +43,7 @@ from netboxlabs.diode.sdk.ingester import (
     Prefix,
     Role,
     Site,
+    SiteGroup,
     Tag,
     VirtualDisk,
     VMInterface,
@@ -606,6 +607,22 @@ def test_virtual_machine_instantiation_with_cluster_without_site():
     assert virtual_machine.status == "active"
     assert virtual_machine.site.name == "Site1"
     assert virtual_machine.cluster.scope_site.name == "Site1"
+
+
+def test_virtual_machine_instantiation_keeps_cluster_scope_site_group():
+    """Check VirtualMachine leaves a cluster that is already scoped to a SiteGroup untouched."""
+    cluster = Cluster(name="gc-us-east1", scope_site_group=SiteGroup(name="SiteGroup1"))
+
+    virtual_machine = VirtualMachine(
+        name="vm1",
+        cluster=cluster,
+        site=Site(name="Site1"),
+    )
+
+    assert cluster.WhichOneof("scope") == "scope_site_group"
+    assert cluster.scope_site_group.name == "SiteGroup1"
+    assert virtual_machine.cluster.WhichOneof("scope") == "scope_site_group"
+    assert virtual_machine.cluster.scope_site_group.name == "SiteGroup1"
 
 
 def test_virtual_disk_instantiation_with_all_fields():


### PR DESCRIPTION
## Problem

`VirtualMachine(cluster=…, site=…)` writes `scope_site` into the caller's `Cluster` message. `Cluster.scope` is a protobuf `oneof`, so that write silently deletes whatever scope the caller had already set — a SiteGroup, Location or Region.

```python
cluster = Cluster(name="c1", scope_site_group=SiteGroup(name="sg-1"))
VirtualMachine(name="vm-1", cluster=cluster, site=Site(name="site-1"))

cluster.WhichOneof("scope")   # "scope_site" — the SiteGroup is gone
```

The guard was `not cluster.HasField("scope_site")`, which is `False` while a *sibling* of the oneof holds the scope. So "unset" reads as true even though the cluster is already scoped, and `CopyFrom` clears it.

## Fix

Guard on `WhichOneof("scope")` instead. This is a strict tightening of the old check — an unscoped cluster is still filled from the VM's site, an already-scoped one is left alone.

## Why it matters downstream

The vCenter integration scopes a Cluster with a SiteGroup when its ESXi hosts span multiple NetBox Sites. Building any VM in that cluster replaced the SiteGroup with that VM's own Site, so the emitted payload carried two contradictory copies of the same Cluster: the root entity with the mutated `scope_site`, and the nested `device.cluster` ref with the correct `scope_site_group`. The root entity is the one that creates/updates the Cluster in NetBox, so the wrong value won — and which Site won depended on which VM happened to be built first.

Measured on `nbl-vmware-vcenter`, multi-site fixture, no integration code changed:

| | root `cluster` | nested `device.cluster` |
|---|---|---|
| released SDK | `scope_site: DefaultSite` | `scope_site_group: SiteGroup-MixedTagCluster` |
| this branch | `scope_site_group: SiteGroup-MixedTagCluster` | `scope_site_group: SiteGroup-MixedTagCluster` |

## Verification

- `pytest tests/` — 214 passed, including a new regression test; `ruff check netboxlabs/ tests/` clean.
- Pre-existing `test_virtual_machine_instantiation_with_cluster_without_site` still passes, so the fill-when-unscoped shortcut is unchanged.
- End-to-end against a live vCenter via `worker-cli --dry-run`, released SDK vs this branch: 144 entities, identical output. Single-site clusters still receive `scope_site`.
- `nbl-vmware-vcenter` suite on this branch: 124 passed, 2 failed. Both failures are golden files that currently record the mutated scope (`duplicate IPs across sites create per-site VRFs`, `mixed site tags produce DefaultSite for untagged hosts`); they will be regenerated on the integrations side.

## Not in this PR

- `ingester.py` is generated, so the same guard needs to go into the generator or the next regeneration will revert it. Suggested general form: if a shortcut's target field belongs to a multi-member oneof, guard on `WhichOneof(<oneof>)`, otherwise `HasField(<field>)`. Today that rewrites exactly 1 of the 20 shortcut writes, and it pre-empts the same bug for `IPAddress.assigned_object`, `MACAddress.assigned_object`, `WirelessLAN.scope`, `VLANGroup.scope`, `Prefix.scope`, `Service.parent_object`, `InventoryItem.component` and `CustomFieldValue.value`.
- Separate finding in the same shortcut table: `IPAddress(assigned_object_vm_interface=…, device=…)` raises `ValueError: Protocol message VMInterface has no "device" field` — `VMInterface` links via `virtual_machine`, so that shortcut targets a field that does not exist on the message.
