### PR TITLE
fix(ingester): don't clear a cluster's scope oneof when building a VirtualMachine

### DIFF
--- a/netboxlabs/diode/sdk/ingester.py
+++ b/netboxlabs/diode/sdk/ingester.py
@@ -7227,7 +7227,7 @@ class VirtualMachine:
         if site is not None:
             if device is not None and not device.HasField("site"):
                 device.site.CopyFrom(site)
-            if cluster is not None and not cluster.HasField("scope_site"):
+            if cluster is not None and not cluster.WhichOneof("scope"):
                 cluster.scope_site.CopyFrom(site)
         if role is not None:
             if device is not None and not device.HasField("role"):

--- a/tests/test_ingester.py
+++ b/tests/test_ingester.py
@@ -43,6 +43,7 @@ from netboxlabs.diode.sdk.ingester import (
     Prefix,
     Role,
     Site,
+    SiteGroup,
     Tag,
     VirtualDisk,
     VMInterface,
@@ -606,6 +607,22 @@ def test_virtual_machine_instantiation_with_cluster_without_site():
     assert virtual_machine.status == "active"
     assert virtual_machine.site.name == "Site1"
     assert virtual_machine.cluster.scope_site.name == "Site1"
+
+
+def test_virtual_machine_instantiation_keeps_cluster_scope_site_group():
+    """Check VirtualMachine leaves a cluster that is already scoped to a SiteGroup untouched."""
+    cluster = Cluster(name="gc-us-east1", scope_site_group=SiteGroup(name="SiteGroup1"))
+
+    virtual_machine = VirtualMachine(
+        name="vm1",
+        cluster=cluster,
+        site=Site(name="Site1"),
+    )
+
+    assert cluster.WhichOneof("scope") == "scope_site_group"
+    assert cluster.scope_site_group.name == "SiteGroup1"
+    assert virtual_machine.cluster.WhichOneof("scope") == "scope_site_group"
+    assert virtual_machine.cluster.scope_site_group.name == "SiteGroup1"
 
 
 def test_virtual_disk_instantiation_with_all_fields():


### PR DESCRIPTION
## Problem

`VirtualMachine(cluster=…, site=…)` writes `scope_site` into the caller's `Cluster` message. `Cluster.scope` is a protobuf `oneof`, so that write silently deletes whatever scope the caller had already set — a SiteGroup, Location or Region.

```python
cluster = Cluster(name="c1", scope_site_group=SiteGroup(name="sg-1"))
VirtualMachine(name="vm-1", cluster=cluster, site=Site(name="site-1"))

cluster.WhichOneof("scope")   # "scope_site" — the SiteGroup is gone
```

The guard was `not cluster.HasField("scope_site")`, which is `False` while a *sibling* of the oneof holds the scope, so the write went ahead and `CopyFrom` cleared the sibling.

## Fix

`ingester.py` is generated code. This is the artifact regenerated from netboxlabs/eng-observability-skunkworks#57, which taught the generator to guard a shortcut target belonging to a oneof with `WhichOneof(<oneof>)` instead of `HasField(<field>)`. Over the current NetBox v4.7.0 generation that is a single line:

```diff
-            if cluster is not None and not cluster.HasField("scope_site"):
+            if cluster is not None and not cluster.WhichOneof("scope"):
                 cluster.scope_site.CopyFrom(site)
```

`WhichOneof` subsumes the old check, so an unscoped cluster is still filled from the VM's site and an already-scoped one is left alone. The other 19 shortcut writes target fields outside a oneof and are unchanged.

Adds a regression test for the case that was failing.

Closes OBS-3803.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
